### PR TITLE
Refactor segment type assignment logic in stat_segment and validate_file_name

### DIFF
--- a/src/asmt.c
+++ b/src/asmt.c
@@ -1365,29 +1365,27 @@ stat_segment(int shmid, as_segment_t** segment, int* error)
 
 	key = key & ~(0xff << AS_XMEM_NS_KEY_SHIFT);
 
-	if (key >= AS_XMEM_ARENA_KEY) {
-		if (primary) {
+	if (primary) {
+		if (key == 0) {
+			sp->type = TYPE_BASE;
+		}
+		else if (key == AS_XMEM_TREEX_KEY) {
+			sp->type = TYPE_TREEX;
+		}
+		else if (key >= AS_XMEM_ARENA_KEY) {
 			sp->type = TYPE_PRI_STAGE;
 		}
-		else if (secondary) {
+	}
+	else if (secondary) {
+		if (key == 0) {
+			sp->type = TYPE_META;
+		}
+		else if (key >= AS_XMEM_ARENA_KEY) {
 			sp->type = TYPE_SEC_STAGE;
 		}
 	}
-	else if (key == AS_XMEM_TREEX_KEY) {
-		if (primary) {
-			sp->type = TYPE_TREEX;
-		}
-	}
 	else {
-		if (primary) {
-			sp->type = TYPE_BASE ;
-		}
-		else if (secondary) {
-			sp->type = TYPE_META ;
-		}
-		else {
-			sp->type = TYPE_DAT_STAGE;
-		}
+		sp->type = TYPE_DAT_STAGE;
 	}
 
 	// Extract stage number from key.
@@ -5224,47 +5222,15 @@ validate_file_name(const char* pathname, as_file_t* fp)
 
 	key = key & ~(0xff << AS_XMEM_NS_KEY_SHIFT);
 
-	if (key >= AS_XMEM_ARENA_KEY) {
-		if (primary) {
-			fp->type = TYPE_PRI_STAGE;
-		} else if (secondary) {
-			fp->type = TYPE_SEC_STAGE;
-		}
-		else if (data) {
-			fp->type = TYPE_DAT_STAGE;
-		}
-		else {
-			// Not a valid Aerospike file type.
-			free(old_ptr);
-			old_ptr = NULL;
-			return false;
-		}
-	}
-	else if (key == AS_XMEM_TREEX_KEY) {
-		if (primary) {
-			fp->type = TYPE_TREEX;
-		}
-	}
-	else if (key > 0) {
-		if (data) {
-			fp->type = TYPE_DAT_STAGE;
-		}
-		else {
-			// Not a valid Aerospike file type.
-			free(old_ptr);
-			old_ptr = NULL;
-			return false;
-		}
-	}
-	else if (key == 0) {
-		if (primary) {
+	if (primary) {
+		if (key == 0) {
 			fp->type = TYPE_BASE;
 		}
-		else if (secondary) {
-			fp->type = TYPE_META;
+		else if (key == AS_XMEM_TREEX_KEY) {
+			fp->type = TYPE_TREEX;
 		}
-		else if (data) {
-			fp->type = TYPE_DAT_STAGE;
+		else if (key >= AS_XMEM_ARENA_KEY) {
+			fp->type = TYPE_PRI_STAGE;
 		}
 		else {
 			// Not a valid Aerospike file type.
@@ -5272,6 +5238,23 @@ validate_file_name(const char* pathname, as_file_t* fp)
 			old_ptr = NULL;
 			return false;
 		}
+	}
+	else if (secondary) {
+		if (key == 0) {
+			fp->type = TYPE_META;
+		}
+		else if (key >= AS_XMEM_ARENA_KEY) {
+			fp->type = TYPE_SEC_STAGE;
+		}
+		else {
+			// Not a valid Aerospike file type.
+			free(old_ptr);
+			old_ptr = NULL;
+			return false;
+		}
+	}
+	else if (data) {
+		fp->type = TYPE_DAT_STAGE;
 	}
 	else {
 		// Not a valid Aerospike file type.


### PR DESCRIPTION
The set of conditionals within `validate_file_name `and `stat_segment `functions are not well guarded and I think can (and have in my case) result in unexpected behavior. In a few of my clusters this oversight ultimately manifests as an error during asmt restore showing `Missing treex segment file` for one or more namespaces. I think the root cause of this is the way that the conditionals in this PR are reading the key variable. My error was due to this oversight in `validate_file_name` but I modified  `stat_segment` here as well because it uses the same logic.

Specifically where the oversight occurs is in the conditional: `else if (key == AS_XMEM_TREEX_KEY) {`. `AS_XMEM_TREEX_KEY` itself just equals 1 (defined earlier in code).  This block contains no nested conditionals to handle the scenario that `primary=false` and `data=true.` This in itself is poorly-guarded. If it is the case that we should never enter the conditional unless `primary=true` then it should throw an error as other blocks here already do. Regardless of whether it's unexpected behavior, what's been happening in my case is we enter this conditional and then because there is no conditional for `data=true`, we never set `fp->type = TYPE_DAT_STAGE`. Therefore I believe `fp->type` maintains whatever value already existed in memory prior (for example, in my case I think it's sometimes inadvertently staying as `TYPE_TREEX` which results in the `Missing treex segment file` error).

At first I considered making the fix here an additional conditional like:
```
else if (key == AS_XMEM_TREEX_KEY) {
  if (primary) {
    fp->type = TYPE_TREEX;
  }
  else if (data) {
    fp->type = TYPE_DATA_STAGE;
  }
}
```

This would fix the problem. However I think it's probably still unexpected behavior that `key == AS_XMEM_TREEX_KEY` returns `true` when `data` is true and so we shouldn't be entering this conditional at all. A better solution therefore, I think, is flip the conditionals as I have it in this PR where we check for `primary` `secondary` `data` first then check for key value.

Also I believe it would be better practice for `stat_segment` to have `else` conditionals at the end of the conditional blocks the same way `validate_file_name ` does. But it didn't already have any so I did not add them because I do not want to accidentally change any expected behavior. This PR effectively only adds guards to what I think was the intended behavior all along.

I can provide a set of namespace .dat file names if you would like to validate any of this behavior and see what I mean.