### PR TITLE
Fix stale segment type causing 'Missing treex segment file' on restore

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,6 +58,19 @@ asmt: target_dir $(ASMT_OBJECTS)
 	@echo "Linking $(ASMT_BINARY)"
 	$(CC) $(LDFLAGS) -o $(ASMT_BINARY) $(ASMT_OBJECTS) $(LIBRARIES)
 
+# Unit tests. The test includes asmt.c to reach its static functions, so it
+# only needs hardware.o (and the same libraries) to link.
+ASMT_TEST_BINARY = $(DIR_BIN)/asmt_test
+HARDWARE_OBJECT = $(DIR_OBJ)/src/hardware.o
+
+.PHONY: test
+test: target_dir $(HARDWARE_OBJECT)
+	@echo "Building $(ASMT_TEST_BINARY)"
+	$(CC) $(CFLAGS) -o $(ASMT_TEST_BINARY) $(INCLUDES) \
+		tests/test_validate_file_name.c $(HARDWARE_OBJECT) $(LIBRARIES)
+	@echo "Running $(ASMT_TEST_BINARY)"
+	./$(ASMT_TEST_BINARY)
+
 .PHONY: rpm
 rpm:
 	$(MAKE) -f pkg/Makefile.rpm

--- a/src/asmt.c
+++ b/src/asmt.c
@@ -1375,6 +1375,12 @@ stat_segment(int shmid, as_segment_t** segment, int* error)
 		else if (key >= AS_XMEM_ARENA_KEY) {
 			sp->type = TYPE_PRI_STAGE;
 		}
+		else {
+			free(*segment);
+			*segment = NULL;
+			*error = ENOENT;
+			return false;
+		}
 	}
 	else if (secondary) {
 		if (key == 0) {
@@ -1382,6 +1388,12 @@ stat_segment(int shmid, as_segment_t** segment, int* error)
 		}
 		else if (key >= AS_XMEM_ARENA_KEY) {
 			sp->type = TYPE_SEC_STAGE;
+		}
+		else {
+			free(*segment);
+			*segment = NULL;
+			*error = ENOENT;
+			return false;
 		}
 	}
 	else {

--- a/src/asmt.c
+++ b/src/asmt.c
@@ -1376,6 +1376,7 @@ stat_segment(int shmid, as_segment_t** segment, int* error)
 			sp->type = TYPE_PRI_STAGE;
 		}
 		else {
+			// Not a valid Aerospike segment type.
 			free(*segment);
 			*segment = NULL;
 			*error = ENOENT;
@@ -1390,6 +1391,7 @@ stat_segment(int shmid, as_segment_t** segment, int* error)
 			sp->type = TYPE_SEC_STAGE;
 		}
 		else {
+			// Not a valid Aerospike segment type.
 			free(*segment);
 			*segment = NULL;
 			*error = ENOENT;

--- a/src/asmt.c
+++ b/src/asmt.c
@@ -399,6 +399,8 @@ static bool analyze_backup(void);
 static bool check_dir(const char* pathname, bool is_write, bool create);
 static bool list_segments(as_segment_t** segments, uint32_t* n_segments,
 		int* error);
+static bool type_from_key_base(bool primary, bool secondary, key_t key_base,
+		as_type* type);
 static bool stat_segment(int shmid, as_segment_t** segment, int* error);
 static int qsort_compare_segments(const void* left, const void* right);
 static bool analyze_backup_candidate(as_segment_t* segments,
@@ -1273,6 +1275,45 @@ list_segments(as_segment_t** segments, uint32_t* n_segments, int* error)
 	return true;
 }
 
+// Determine the segment type from the segment class (primary / secondary /
+// data) and the key base. Returns false if the key base is not valid for the
+// class. Shared by stat_segment() and validate_file_name().
+
+static bool
+type_from_key_base(bool primary, bool secondary, key_t key_base, as_type* type)
+{
+	if (primary) {
+		if (key_base == 0) {
+			*type = TYPE_BASE;
+		}
+		else if (key_base == AS_XMEM_TREEX_KEY) {
+			*type = TYPE_TREEX;
+		}
+		else if (key_base >= AS_XMEM_ARENA_KEY) {
+			*type = TYPE_PRI_STAGE;
+		}
+		else {
+			return false;
+		}
+	}
+	else if (secondary) {
+		if (key_base == 0) {
+			*type = TYPE_META;
+		}
+		else if (key_base >= AS_XMEM_ARENA_KEY) {
+			*type = TYPE_SEC_STAGE;
+		}
+		else {
+			return false;
+		}
+	}
+	else {
+		*type = TYPE_DAT_STAGE;
+	}
+
+	return true;
+}
+
 // Get information about a single shared memory segment by shmid.
 // Validates whether a segment is an Aerospike database segment.
 
@@ -1365,41 +1406,12 @@ stat_segment(int shmid, as_segment_t** segment, int* error)
 
 	key = key & ~(0xff << AS_XMEM_NS_KEY_SHIFT);
 
-	if (primary) {
-		if (key == 0) {
-			sp->type = TYPE_BASE;
-		}
-		else if (key == AS_XMEM_TREEX_KEY) {
-			sp->type = TYPE_TREEX;
-		}
-		else if (key >= AS_XMEM_ARENA_KEY) {
-			sp->type = TYPE_PRI_STAGE;
-		}
-		else {
-			// Not a valid Aerospike segment type.
-			free(*segment);
-			*segment = NULL;
-			*error = ENOENT;
-			return false;
-		}
-	}
-	else if (secondary) {
-		if (key == 0) {
-			sp->type = TYPE_META;
-		}
-		else if (key >= AS_XMEM_ARENA_KEY) {
-			sp->type = TYPE_SEC_STAGE;
-		}
-		else {
-			// Not a valid Aerospike segment type.
-			free(*segment);
-			*segment = NULL;
-			*error = ENOENT;
-			return false;
-		}
-	}
-	else {
-		sp->type = TYPE_DAT_STAGE;
+	if (!type_from_key_base(primary, secondary, key, &sp->type)) {
+		// Not a valid Aerospike segment type.
+		free(*segment);
+		*segment = NULL;
+		*error = ENOENT;
+		return false;
 	}
 
 	// Extract stage number from key.
@@ -5236,41 +5248,7 @@ validate_file_name(const char* pathname, as_file_t* fp)
 
 	key = key & ~(0xff << AS_XMEM_NS_KEY_SHIFT);
 
-	if (primary) {
-		if (key == 0) {
-			fp->type = TYPE_BASE;
-		}
-		else if (key == AS_XMEM_TREEX_KEY) {
-			fp->type = TYPE_TREEX;
-		}
-		else if (key >= AS_XMEM_ARENA_KEY) {
-			fp->type = TYPE_PRI_STAGE;
-		}
-		else {
-			// Not a valid Aerospike file type.
-			free(old_ptr);
-			old_ptr = NULL;
-			return false;
-		}
-	}
-	else if (secondary) {
-		if (key == 0) {
-			fp->type = TYPE_META;
-		}
-		else if (key >= AS_XMEM_ARENA_KEY) {
-			fp->type = TYPE_SEC_STAGE;
-		}
-		else {
-			// Not a valid Aerospike file type.
-			free(old_ptr);
-			old_ptr = NULL;
-			return false;
-		}
-	}
-	else if (data) {
-		fp->type = TYPE_DAT_STAGE;
-	}
-	else {
+	if (!type_from_key_base(primary, secondary, key, &fp->type)) {
 		// Not a valid Aerospike file type.
 		free(old_ptr);
 		old_ptr = NULL;

--- a/src/asmt.c
+++ b/src/asmt.c
@@ -1365,29 +1365,27 @@ stat_segment(int shmid, as_segment_t** segment, int* error)
 
 	key = key & ~(0xff << AS_XMEM_NS_KEY_SHIFT);
 
-	if (key >= AS_XMEM_ARENA_KEY) {
-		if (primary) {
+	if (primary) {
+		if (key == 0) {
+			sp->type = TYPE_BASE;
+		}
+		else if (key == AS_XMEM_TREEX_KEY) {
+			sp->type = TYPE_TREEX;
+		}
+		else if (key >= AS_XMEM_ARENA_KEY) {
 			sp->type = TYPE_PRI_STAGE;
 		}
-		else if (secondary) {
+	}
+	else if (secondary) {
+		if (key == 0) {
+			sp->type = TYPE_META;
+		}
+		else if (key >= AS_XMEM_ARENA_KEY) {
 			sp->type = TYPE_SEC_STAGE;
 		}
 	}
-	else if (key == AS_XMEM_TREEX_KEY) {
-		if (primary) {
-			sp->type = TYPE_TREEX;
-		}
-	}
 	else {
-		if (primary) {
-			sp->type = TYPE_BASE ;
-		}
-		else if (secondary) {
-			sp->type = TYPE_META ;
-		}
-		else {
-			sp->type = TYPE_DAT_STAGE;
-		}
+		sp->type = TYPE_DAT_STAGE;
 	}
 
 	// Extract stage number from key.
@@ -5224,47 +5222,15 @@ validate_file_name(const char* pathname, as_file_t* fp)
 
 	key = key & ~(0xff << AS_XMEM_NS_KEY_SHIFT);
 
-	if (key >= AS_XMEM_ARENA_KEY) {
-		if (primary) {
-			fp->type = TYPE_PRI_STAGE;
-		} else if (secondary) {
-			fp->type = TYPE_SEC_STAGE;
-		}
-		else if (data) {
-			fp->type = TYPE_DAT_STAGE;
-		}
-		else {
-			// Not a valid Aerospike file type.
-			free(old_ptr);
-			old_ptr = NULL;
-			return false;
-		}
-	}
-	else if (key == AS_XMEM_TREEX_KEY) {
-		if (primary) {
-			fp->type = TYPE_TREEX;
-		}
-	}
-	else if (key > 0) {
-		if (data) {
-			fp->type = TYPE_DAT_STAGE;
-		}
-		else {
-			// Not a valid Aerospike file type.
-			free(old_ptr);
-			old_ptr = NULL;
-			return false;
-		}
-	}
-	else if (key == 0) {
-		if (primary) {
+	if (primary) {
+		if (key == 0) {
 			fp->type = TYPE_BASE;
 		}
-		else if (secondary) {
-			fp->type = TYPE_META;
+		else if (key == AS_XMEM_TREEX_KEY) {
+			fp->type = TYPE_TREEX;
 		}
-		else if (data) {
-			fp->type = TYPE_DAT_STAGE;
+		else if (key >= AS_XMEM_ARENA_KEY) {
+			fp->type = TYPE_PRI_STAGE;
 		}
 		else {
 			// Not a valid Aerospike file type.
@@ -5272,6 +5238,23 @@ validate_file_name(const char* pathname, as_file_t* fp)
 			old_ptr = NULL;
 			return false;
 		}
+	}
+	else if (secondary) {
+		if (key == 0) {
+			fp->type = TYPE_META;
+		}
+		else if (key >= AS_XMEM_ARENA_KEY) {
+			fp->type = TYPE_SEC_STAGE;
+		}
+		else {
+			// Not a valid Aerospike file type.
+			free(old_ptr);
+			old_ptr = NULL;
+			return false;
+		}
+	}
+	else if (data) {
+		fp->type = TYPE_DAT_STAGE;
 	}
 	else {
 		// Not a valid Aerospike file type.

--- a/tests/test_validate_file_name.c
+++ b/tests/test_validate_file_name.c
@@ -1,0 +1,159 @@
+/*
+ * test_validate_file_name.c
+ *
+ * Copyright (C) 2026 Aerospike, Inc.
+ *
+ * Portions may be licensed to Aerospike, Inc. under one or more contributor
+ * license agreements.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see http://www.gnu.org/licenses/
+ */
+
+//==========================================================
+// Unit tests for validate_file_name().
+//
+// validate_file_name() is static and parses a segment file name (an 8-hex-digit
+// System V shared-memory key plus a ".dat"/".dat.gz" extension) into an
+// as_file_t, deciding the segment's type from the key. It touches no shared
+// memory or file system, so it can be exercised directly. We reach the static
+// function by including the translation unit and renaming its main().
+//
+// The key layout (8 hex digits) is: CC I NN KKK
+//   CC  - class byte:  ae = primary, a2 = secondary, ad = data
+//   I   - instance nibble (0..15)
+//   NN  - namespace id  (0x01..0x20)
+//   KKK - key base:     0 = base/meta, 1 = treex, >= 0x100 = arena stage
+//
+// The regression this guards (asmt PR #38 / #40): a data segment whose key base
+// equals AS_XMEM_TREEX_KEY (1) used to fall through without a type being set,
+// inheriting a stale TYPE_TREEX and producing "Missing treex segment file" on
+// restore. It must now resolve to TYPE_DAT_STAGE.
+//
+
+int asmt_main_unused(int argc, char* argv[]);
+#define main asmt_main_unused
+#include "asmt.c"
+#undef main
+
+#include <stdio.h>
+#include <string.h>
+
+static int g_checks = 0;
+static int g_failures = 0;
+
+// basename() may modify its argument, so hand validate_file_name() a mutable
+// copy rather than a string literal.
+static bool
+run(const char* file_name, as_file_t* fp)
+{
+	char buf[64];
+	snprintf(buf, sizeof(buf), "%s", file_name);
+	memset(fp, 0xEE, sizeof(*fp)); // poison, so an unset type would be caught
+	return validate_file_name(buf, fp);
+}
+
+static void
+expect_valid(const char* file_name, as_type want_type, uint32_t want_stage,
+		const char* desc)
+{
+	as_file_t fp;
+	g_checks++;
+
+	if (! run(file_name, &fp)) {
+		printf("FAIL  %-28s %s: expected valid, was rejected\n", file_name, desc);
+		g_failures++;
+		return;
+	}
+
+	if (fp.type != want_type) {
+		printf("FAIL  %-28s %s: type=%d, expected %d\n", file_name, desc,
+				(int)fp.type, (int)want_type);
+		g_failures++;
+		return;
+	}
+
+	if (fp.stage != want_stage) {
+		printf("FAIL  %-28s %s: stage=0x%x, expected 0x%x\n", file_name, desc,
+				fp.stage, want_stage);
+		g_failures++;
+		return;
+	}
+
+	printf("ok    %-28s %s\n", file_name, desc);
+}
+
+static void
+expect_invalid(const char* file_name, const char* desc)
+{
+	as_file_t fp;
+	g_checks++;
+
+	if (run(file_name, &fp)) {
+		printf("FAIL  %-28s %s: expected rejected, was accepted (type=%d)\n",
+				file_name, desc, (int)fp.type);
+		g_failures++;
+		return;
+	}
+
+	printf("ok    %-28s %s\n", file_name, desc);
+}
+
+int
+main(void)
+{
+	printf("validate_file_name() tests\n");
+
+	// Valid segments, instance 0, namespace id 1.
+	expect_valid("ae001000.dat",    TYPE_BASE,      0,     "primary base");
+	expect_valid("ae001001.dat",    TYPE_TREEX,     0,     "primary treex");
+	expect_valid("ae001100.dat",    TYPE_PRI_STAGE, 0x100, "primary arena stage");
+	expect_valid("a2001000.dat",    TYPE_META,      0,     "secondary meta");
+	expect_valid("a2001100.dat",    TYPE_SEC_STAGE, 0x100, "secondary arena stage");
+	expect_valid("ad001000.dat",    TYPE_DAT_STAGE, 0,     "data stage, key base 0");
+	expect_valid("ad001002.dat",    TYPE_DAT_STAGE, 2,     "data stage, key base 2");
+	expect_valid("ad001100.dat",    TYPE_DAT_STAGE, 0x100, "data stage, arena-range key");
+
+	// The regression: data segment whose key base == AS_XMEM_TREEX_KEY (1).
+	expect_valid("ad001001.dat",    TYPE_DAT_STAGE, 1,     "data stage, key base 1 (regression)");
+
+	// Compressed extension must be accepted too.
+	expect_valid("ae001100.dat.gz", TYPE_PRI_STAGE, 0x100, "primary arena stage, .gz");
+
+	// Uppercase hex is accepted.
+	expect_valid("AE001001.dat",    TYPE_TREEX,     0,     "primary treex, uppercase");
+
+	// Invalid: recognized class but unrecognized key base.
+	expect_invalid("ae001002.dat", "primary, key base 2 (not base/treex/arena)");
+	expect_invalid("a2001001.dat", "secondary, key base 1 (not meta/arena)");
+
+	// Invalid: primary arena stage out of range (> MAX_ARENA 0x8ff).
+	expect_invalid("ae001900.dat", "primary arena stage out of range");
+
+	// Invalid: not an Aerospike class byte.
+	expect_invalid("12001000.dat", "non-Aerospike class byte");
+
+	// Invalid: namespace id out of range.
+	expect_invalid("ae000000.dat", "nsid 0 (< MIN_NSID)");
+	expect_invalid("ae021000.dat", "nsid 33 (> MAX_NSID)");
+
+	// Invalid: malformed names.
+	expect_invalid("ae0010.dat",   "wrong length");
+	expect_invalid("ae00100g.dat", "non-hex character");
+	expect_invalid("ae001000.txt", "wrong extension");
+	expect_invalid("ae001000",     "no extension");
+
+	printf("\n%d/%d checks passed\n", g_checks - g_failures, g_checks);
+
+	return g_failures == 0 ? 0 : 1;
+}

--- a/tests/test_validate_file_name.c
+++ b/tests/test_validate_file_name.c
@@ -65,7 +65,7 @@ run(const char* file_name, as_file_t* fp)
 
 static void
 expect_valid(const char* file_name, as_type want_type, uint32_t want_stage,
-		const char* desc)
+		uint32_t want_inst, const char* desc)
 {
 	as_file_t fp;
 	g_checks++;
@@ -86,6 +86,13 @@ expect_valid(const char* file_name, as_type want_type, uint32_t want_stage,
 	if (fp.stage != want_stage) {
 		printf("FAIL  %-28s %s: stage=0x%x, expected 0x%x\n", file_name, desc,
 				fp.stage, want_stage);
+		g_failures++;
+		return;
+	}
+
+	if (fp.inst != want_inst) {
+		printf("FAIL  %-28s %s: inst=%u, expected %u\n", file_name, desc,
+				fp.inst, want_inst);
 		g_failures++;
 		return;
 	}
@@ -115,23 +122,28 @@ main(void)
 	printf("validate_file_name() tests\n");
 
 	// Valid segments, instance 0, namespace id 1.
-	expect_valid("ae001000.dat",    TYPE_BASE,      0,     "primary base");
-	expect_valid("ae001001.dat",    TYPE_TREEX,     0,     "primary treex");
-	expect_valid("ae001100.dat",    TYPE_PRI_STAGE, 0x100, "primary arena stage");
-	expect_valid("a2001000.dat",    TYPE_META,      0,     "secondary meta");
-	expect_valid("a2001100.dat",    TYPE_SEC_STAGE, 0x100, "secondary arena stage");
-	expect_valid("ad001000.dat",    TYPE_DAT_STAGE, 0,     "data stage, key base 0");
-	expect_valid("ad001002.dat",    TYPE_DAT_STAGE, 2,     "data stage, key base 2");
-	expect_valid("ad001100.dat",    TYPE_DAT_STAGE, 0x100, "data stage, arena-range key");
+	expect_valid("ae001000.dat",    TYPE_BASE,      0,     0, "primary base");
+	expect_valid("ae001001.dat",    TYPE_TREEX,     0,     0, "primary treex");
+	expect_valid("ae001100.dat",    TYPE_PRI_STAGE, 0x100, 0, "primary arena stage");
+	expect_valid("a2001000.dat",    TYPE_META,      0,     0, "secondary meta");
+	expect_valid("a2001100.dat",    TYPE_SEC_STAGE, 0x100, 0, "secondary arena stage");
+	expect_valid("ad001000.dat",    TYPE_DAT_STAGE, 0,     0, "data stage, key base 0");
+	expect_valid("ad001002.dat",    TYPE_DAT_STAGE, 2,     0, "data stage, key base 2");
+	expect_valid("ad001100.dat",    TYPE_DAT_STAGE, 0x100, 0, "data stage, arena-range key");
 
 	// The regression: data segment whose key base == AS_XMEM_TREEX_KEY (1).
-	expect_valid("ad001001.dat",    TYPE_DAT_STAGE, 1,     "data stage, key base 1 (regression)");
+	expect_valid("ad001001.dat",    TYPE_DAT_STAGE, 1,     0, "data stage, key base 1 (regression)");
+
+	// Non-zero instance nibble (including MAX_INST, 15).
+	expect_valid("ae101001.dat",    TYPE_TREEX,     0,     1,  "primary treex, instance 1");
+	expect_valid("a2301100.dat",    TYPE_SEC_STAGE, 0x100, 3,  "secondary arena stage, instance 3");
+	expect_valid("adf01001.dat",    TYPE_DAT_STAGE, 1,     15, "data stage, key base 1, instance 15");
 
 	// Compressed extension must be accepted too.
-	expect_valid("ae001100.dat.gz", TYPE_PRI_STAGE, 0x100, "primary arena stage, .gz");
+	expect_valid("ae001100.dat.gz", TYPE_PRI_STAGE, 0x100, 0, "primary arena stage, .gz");
 
 	// Uppercase hex is accepted.
-	expect_valid("AE001001.dat",    TYPE_TREEX,     0,     "primary treex, uppercase");
+	expect_valid("AE001001.dat",    TYPE_TREEX,     0,     0, "primary treex, uppercase");
 
 	// Invalid: recognized class but unrecognized key base.
 	expect_invalid("ae001002.dat", "primary, key base 2 (not base/treex/arena)");


### PR DESCRIPTION
Supersedes #38 (from @JamesLydon). This branch preserves that commit and adds one follow-up fix; opened from an `aerospike/asmt` branch so we can carry it to merge.

## Root cause

`list_files()` reuses a single `as_file_t valid_file` struct across the `readdir()` loop. In the previous key-first branch order, a data segment whose masked key base equals `AS_XMEM_TREEX_KEY` (1) entered the treex branch, which only assigns a type when `primary`. For a data segment it set nothing and fell through, so `fp->type` inherited the stale value from the previous directory entry — often `TYPE_TREEX` — which surfaces during restore as `Missing treex segment file`.

## Fix

- **#38's change (preserved):** restructure `stat_segment()` and `validate_file_name()` to route by segment class (primary / secondary / data) first, then key base. This removes the dependency on stale struct state and unconditionally assigns `TYPE_DAT_STAGE` to data segments.
- **Follow-up (this branch):** `validate_file_name()` keeps a trailing `else` on its primary and secondary blocks that rejects an unrecognized key base (`free` + return false); the #38 rewrite of `stat_segment()` dropped those. Because `*segment` is `malloc`'d (not zeroed), a primary segment with key base in `[2, 0xff]` or a secondary segment with key base in `[1, 0xff]` would leave `sp->type` uninitialized and `stat_segment()` would still return true, producing an uninitialized read. No legitimate Aerospike segment hits that range, but foreign/corrupt shmem carrying the primary/secondary magic could. Added the matching `else` guards (reject with `ENOENT`) so `stat_segment()` stays symmetric with `validate_file_name()`.

## Verification

Builds clean under the default `-Wall -Wextra` flags (`make`). No test harness exists in this repo; validated by build and code review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)