### PR TITLE
TOOLS-4159 - port unified version/build-number script from aerospike-server

### DIFF
--- a/build/version
+++ b/build/version
@@ -23,10 +23,10 @@
 #
 # build_number counts first-parent commits since the anchoring x.y.z tag (0 when
 # HEAD is exactly on the tag). Non-master branches always return 1.
+# --first-parent requires git >= 2.20 (debian:10+; ubuntu-18.04/git 2.17 is below).
 #
-# A CI environment that pre-computes the version into /work/VERSION (with the
-# event payload in /work/EVENT) is honored when those files exist; otherwise the
-# git-describe path below runs.
+# Version is always derived from git tags via git-describe (through make print-REV).
+# No external pre-baked version files are consumed.
 
 # Fail on unset variables and pipeline errors. Intentionally omit -e so git
 # commands that legitimately fail (no matching tag) can fall through with || true.
@@ -92,28 +92,30 @@ _anchor_tag() {
     echo "$tag"
 }
 
-# Resolve the git ref for CI branch detection. Prefer GITHUB_REF when set,
-# then parse /work/EVENT. jq handles normal JSON; grep fallback tolerates
-# spaced payloads ("ref": "...") that the original compact-json grep missed.
-_ci_ref() {
-    if [[ -n "${GITHUB_REF:-}" ]]; then
-        echo "$GITHUB_REF"
-        return
+# Run git describe for version resolution. On failure (unsupported git, missing
+# tags in a shallow clone, etc.) warn to stderr before falling back to bare SHA
+# so mis-provisioned runners are visible instead of silently SHA-versioned packages.
+_describe_rev() {
+    local strip_suffix="${1:-false}"
+    local rev err
+
+    err="$(mktemp)"
+    rev="$(git describe --first-parent --tags --always --abbrev=9 --long \
+        --match "$TAG_MATCH" 2>"$err")" || rev=""
+    if [[ -z "$rev" ]]; then
+        echo "warning: git describe failed ($(tr -d '\n' < "$err")): falling back to commit SHA" >&2
+        rev="$(git rev-parse --short=9 HEAD)"
     fi
-    if [[ ! -f /work/EVENT ]]; then
-        return
+    rm -f "$err"
+
+    if [[ "$strip_suffix" == true ]]; then
+        rev="$(echo "$rev" | _strip_describe_suffix)"
     fi
-    if command -v jq >/dev/null 2>&1; then
-        jq -r '.ref // empty' /work/EVENT 2>/dev/null
-        return
-    fi
-    grep -oE '"ref"[[:space:]]*:[[:space:]]*"[^"]*"' /work/EVENT 2>/dev/null |
-        head -1 | sed -E 's/.*"([^"]*)".*/\1/'
+    echo "$rev"
 }
 
-# Determine branch when not in the /work/VERSION CI path. Tries, in order:
-# local branch name, GitHub/GitLab CI env vars (covers detached HEAD checkouts),
-# then the first remote branch containing HEAD (legacy fallback).
+# Determine branch name. Tries, in order: local branch name, common CI env vars
+# (covers detached HEAD checkouts), then the first remote branch containing HEAD.
 _resolve_branch() {
     local branch=""
 
@@ -163,19 +165,6 @@ _build_number() {
     fi
 }
 
-# CI-only: when /work/VERSION carries a describe string (x.y.z-n-g<sha>), use
-# the embedded n rather than recomputing from git. Prevents mismatches when the
-# CI checkout is shallow or tags are not fully fetched.
-_build_number_from_version() {
-    local ver="$1" branch="$2"
-
-    if [[ "$ver" =~ -([0-9]+)-g[0-9a-f]+$ ]]; then
-        echo "${BASH_REMATCH[1]}"
-        return
-    fi
-    _build_number "$branch"
-}
-
 # Shared release-line output for version_only and full modes on master.
 _emit_release_version() {
     local rev="$1" branch="$2" output_mode="$3"
@@ -186,12 +175,15 @@ _emit_release_version() {
         local bn
         bn="$(_build_number "$branch")"
         # Omit -n when n is 0 (HEAD exactly on the release tag).
-        [[ "$bn" == "0" ]] && echo "$rev" || echo "${rev}-${bn}"
+        if [[ "$bn" == "0" ]]; then
+            echo "$rev"
+        else
+            echo "${rev}-${bn}"
+        fi
         ;;
     esac
 }
 
-# Git-describe path requires a repo; the /work/VERSION CI path does not.
 _require_git_repo() {
     git rev-parse --git-dir >/dev/null 2>&1 || {
         echo "error: not a git repository" >&2
@@ -202,44 +194,9 @@ _require_git_repo() {
 # ---------------------------------------------------------------------------
 # Determine branch / release-line flag
 # ---------------------------------------------------------------------------
-is_release_line=false
-
-if [[ -f /work/VERSION ]]; then
-    # CI environment: read pre-computed version and derive branch from event payload.
-    rev="$(cat /work/VERSION)"
-    REF="$(_ci_ref)"
-    if [[ "$REF" == "refs/heads/master" ]]; then
-        is_release_line=true
-    fi
-
-    if [[ "$is_release_line" == true ]]; then
-        rev="$(echo "$rev" | _strip_describe_suffix)"
-        branch="master" # placeholder; only used for _build_number below
-    else
-        branch=""
-    fi
-
-    case "$mode" in
-    version_only) echo "$rev" ;;
-    build_only) _build_number_from_version "$rev" "${branch:-}" ;;
-    full)
-        if [[ "$is_release_line" == true ]]; then
-            # Re-read the raw VERSION for build-number extraction (before suffix strip).
-            bn="$(_build_number_from_version "$(cat /work/VERSION)" "${branch:-}")"
-            [[ "$bn" == "0" ]] && echo "$rev" || echo "${rev}-${bn}"
-        else
-            echo "$rev"
-        fi
-        ;;
-    esac
-    exit 0
-fi
-
-# ---------------------------------------------------------------------------
-# Git-describe path (local / standard CI without /work/VERSION)
-# ---------------------------------------------------------------------------
 _require_git_repo
 
+is_release_line=false
 branch="$(_resolve_branch)"
 
 if _is_release_branch "$branch"; then
@@ -253,17 +210,9 @@ fi
 
 # Anchor on the bare x.y.z tag only (never a leading-v ship tag).
 if [[ "$is_release_line" == true ]]; then
-    rev="$(git describe --first-parent --tags --always --abbrev=9 --long \
-        --match "$TAG_MATCH" 2>/dev/null | _strip_describe_suffix || true)"
-    if [[ -z "$rev" ]]; then
-        rev="$(git rev-parse --short=9 HEAD)"
-    fi
+    rev="$(_describe_rev true)"
     _emit_release_version "$rev" "$branch" "$mode"
 else
-    rev="$(git describe --first-parent --tags --always --abbrev=9 --long \
-        --match "$TAG_MATCH" 2>/dev/null || true)"
-    if [[ -z "$rev" ]]; then
-        rev="$(git rev-parse --short=9 HEAD)"
-    fi
+    rev="$(_describe_rev false)"
     echo "$rev"
 fi

--- a/build/version
+++ b/build/version
@@ -1,11 +1,149 @@
-#!/bin/bash
+#!/usr/bin/env bash
+#
+# Unified version/build-number script for asmt. All three outputs are available:
+#
+# Usage:
+#   build/version              -> master: x.y.z-n; dev branches: git describe with SHA
+#   build/version -v           -> master: x.y.z (bare);
+#                                 dev branches: git describe with SHA (same as default)
+#   build/version -r           -> master: build number n; dev branches: 1
+#
+# Consumed by pkg/Makefile.deb and pkg/Makefile.rpm, which both call the default
+# mode for the package Version: field (the rpm Makefile maps '-' to '_').
+#
+# Resolution rules:
+# - Always anchors on the bare x.y.z release tag via
+#   --match '[0-9]*.[0-9]*.[0-9]*'; if none is reachable it falls back to a
+#   v-prefixed tag, then to the short SHA. It never emits a leading 'v', which
+#   the Debian Version: field rejects ("does not start with digit").
+# - master: strip the describe --long suffix to x.y.z; default appends -n
+#   (omitted when n is 0, i.e. HEAD is exactly on the release tag, so official
+#   release builds stay bare x.y.z).
+# - Dev branches: keep the full describe output (-<n>-g<sha>); build number is 1.
+#
+# build_number counts first-parent commits since the anchoring x.y.z tag (0 when
+# HEAD is exactly on the tag). Non-master branches always return 1.
+#
+# A CI environment that pre-computes the version into /work/VERSION (with the
+# event payload in /work/EVENT) is honored when those files exist; otherwise the
+# git-describe path below runs.
 
-rev=`git describe`
-subbuild=`echo $rev | awk -F'-' '{print $2}'`
+mode=full # full (default): x.y.z-n; version_only: x.y.z; build_only: n
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+    -v) mode=version_only ;;
+    -r) mode=build_only ;;
+    *)
+        echo "Usage: $(basename "$0") [-v|-r]" >&2
+        exit 1
+        ;;
+    esac
+    shift
+done
 
-if [ "$subbuild" != "" ]
-then
-#  rev=`echo $rev | awk -F'-' '{printf("%s-%s\n",$1,$2)}'`
-  rev=`echo $rev | awk -F'-' '{printf("%s\n",$1)}'`
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# ---------------------------------------------------------------------------
+# Build-number calculation
+# ---------------------------------------------------------------------------
+_build_number() {
+    local bn_branch="$1"
+
+    if [[ "$bn_branch" != "master" ]]; then
+        echo "1"
+        return
+    fi
+
+    local base_tag
+    base_tag=$(git describe --first-parent --tags --abbrev=0 \
+        --match '[0-9]*.[0-9]*.[0-9]*' 2>/dev/null) || true
+    if [[ -z "$base_tag" ]]; then
+        base_tag=$(git describe --first-parent --tags --abbrev=0 \
+            --match 'v[0-9]*.[0-9]*.[0-9]*' 2>/dev/null) || true
+    fi
+
+    if [[ -n "$base_tag" ]]; then
+        git rev-list --first-parent --count "${base_tag}..HEAD"
+    else
+        echo "1"
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Determine branch
+# ---------------------------------------------------------------------------
+is_release_line=false
+
+if [[ -f /work/VERSION ]]; then
+    # CI environment: read pre-computed version and derive branch from event payload.
+    rev="$(cat /work/VERSION)"
+    if [[ -f /work/EVENT ]]; then
+        REF="$(grep -o '"ref":"[^"]*"' /work/EVENT 2>/dev/null | head -1 | cut -d'"' -f4)"
+        if [[ "$REF" == "refs/heads/master" ]]; then
+            is_release_line=true
+        fi
+    fi
+    if [[ "$is_release_line" == true ]]; then
+        rev="$(echo "$rev" | sed 's/-[0-9]*-g[0-9a-f]*$//')"
+        branch="master" # placeholder; only used for _build_number below
+    else
+        branch=""
+    fi
+
+    case "$mode" in
+    version_only) echo "$rev" ;;
+    build_only) _build_number "${branch:-}" ;;
+    full)
+        if [[ "$is_release_line" == true ]]; then
+            bn="$(_build_number "${branch:-}")"
+            [[ "$bn" == "0" ]] && echo "$rev" || echo "${rev}-${bn}"
+        else
+            echo "$rev"
+        fi
+        ;;
+    esac
+    exit 0
 fi
-echo $rev
+
+# ---------------------------------------------------------------------------
+# Git-describe path (local / standard CI without /work/VERSION)
+# ---------------------------------------------------------------------------
+branch="$(git branch --show-current)"
+
+if [[ -z "$branch" ]]; then
+    branch="$(git branch -r --contains HEAD | grep -v HEAD | head -1 |
+        sed -e 's/origin\///' -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
+fi
+
+if [[ "$branch" == "master" ]]; then
+    is_release_line=true
+fi
+
+if [[ "$mode" == "build_only" ]]; then # -r
+    _build_number "$branch"
+    exit 0
+fi
+
+# Anchor on the bare x.y.z tag only (never a leading-v ship tag).
+if [[ "$is_release_line" == true ]]; then
+    rev="$(git describe --first-parent --tags --always --abbrev=9 --long \
+        --match '[0-9]*.[0-9]*.[0-9]*' 2>/dev/null |
+        sed 's/-[0-9]*-g[0-9a-f]*$//')"
+    if [[ -z "$rev" ]]; then
+        rev="$(git rev-parse --short=9 HEAD)"
+    fi
+    case "$mode" in
+    version_only) echo "$rev" ;;
+    full)
+        bn="$(_build_number "$branch")"
+        [[ "$bn" == "0" ]] && echo "$rev" || echo "${rev}-${bn}"
+        ;;
+    esac
+else
+    rev="$(git describe --first-parent --tags --always --abbrev=9 --long \
+        --match '[0-9]*.[0-9]*.[0-9]*' 2>/dev/null)"
+    if [[ -z "$rev" ]]; then
+        rev="$(git rev-parse --short=9 HEAD)"
+    fi
+    echo "$rev"
+fi

--- a/build/version
+++ b/build/version
@@ -8,14 +8,16 @@
 #                                 dev branches: git describe with SHA (same as default)
 #   build/version -r           -> master: build number n; dev branches: 1
 #
-# Consumed by pkg/Makefile.deb and pkg/Makefile.rpm, which both call the default
-# mode for the package Version: field (the rpm Makefile maps '-' to '_').
+# Consumed by pkg/Makefile.rpm and pkg/Makefile.deb: REV = `build/version -v`
+# (bare x.y.z; the rpm Makefile maps '-' to '_') for the package Version, and the
+# build number (`build/version -r` + 1) feeds the RPM Release / DEB revision.
 #
 # Resolution rules:
 # - Always anchors on the bare x.y.z release tag via
-#   --match '[0-9][0-9]*.[0-9][0-9]*.[0-9][0-9]*'; if none is reachable it falls
-#   back to a v-prefixed tag, then to the short SHA. It never emits a leading 'v',
-#   which the Debian Version: field rejects ("does not start with digit").
+#   --match '[0-9]*.[0-9]*.[0-9]*'; if none is reachable the emitted version falls
+#   back to the short SHA (a v-prefixed tag is consulted only for the build-number
+#   anchor, never emitted). It never emits a leading 'v', which the Debian
+#   Version: field rejects ("does not start with digit").
 # - master: strip the describe --long suffix to x.y.z; default appends -n
 #   (omitted when n is 0, i.e. HEAD is exactly on the release tag, so official
 #   release builds stay bare x.y.z).

--- a/build/version
+++ b/build/version
@@ -13,9 +13,9 @@
 #
 # Resolution rules:
 # - Always anchors on the bare x.y.z release tag via
-#   --match '[0-9]*.[0-9]*.[0-9]*'; if none is reachable it falls back to a
-#   v-prefixed tag, then to the short SHA. It never emits a leading 'v', which
-#   the Debian Version: field rejects ("does not start with digit").
+#   --match '[0-9][0-9]*.[0-9][0-9]*.[0-9][0-9]*'; if none is reachable it falls
+#   back to a v-prefixed tag, then to the short SHA. It never emits a leading 'v',
+#   which the Debian Version: field rejects ("does not start with digit").
 # - master: strip the describe --long suffix to x.y.z; default appends -n
 #   (omitted when n is 0, i.e. HEAD is exactly on the release tag, so official
 #   release builds stay bare x.y.z).
@@ -28,11 +28,28 @@
 # event payload in /work/EVENT) is honored when those files exist; otherwise the
 # git-describe path below runs.
 
+# Fail on unset variables and pipeline errors. Intentionally omit -e so git
+# commands that legitimately fail (no matching tag) can fall through with || true.
+set -uo pipefail
+
 mode=full # full (default): x.y.z-n; version_only: x.y.z; build_only: n
 while [[ $# -gt 0 ]]; do
     case "$1" in
-    -v) mode=version_only ;;
-    -r) mode=build_only ;;
+    -v)
+        # Reject combining -v and -r.
+        if [[ "$mode" != "full" ]]; then
+            echo "Usage: $(basename "$0") [-v|-r]" >&2
+            exit 1
+        fi
+        mode=version_only
+        ;;
+    -r)
+        if [[ "$mode" != "full" ]]; then
+            echo "Usage: $(basename "$0") [-v|-r]" >&2
+            exit 1
+        fi
+        mode=build_only
+        ;;
     *)
         echo "Usage: $(basename "$0") [-v|-r]" >&2
         exit 1
@@ -41,7 +58,90 @@ while [[ $# -gt 0 ]]; do
     shift
 done
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# Glob patterns for semver x.y.z tags. Require at least one digit per segment
+# ([0-9][0-9]* instead of [0-9]*) to avoid matching empty or degenerate tags.
+TAG_MATCH='[0-9][0-9]*.[0-9][0-9]*.[0-9][0-9]*'
+VTAG_MATCH="v${TAG_MATCH}"
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+# Centralizes the release-branch check (asmt uses master only; no hotfix/* lines).
+_is_release_branch() {
+    [[ "$1" == "master" ]]
+}
+
+# Strip git describe --long suffix (-<n>-g<sha>) leaving bare x.y.z.
+# Uses [0-9]+ (one or more digits) so we do not over-match on unusual tag names.
+_strip_describe_suffix() {
+    sed -E 's/-[0-9]+-g[0-9a-f]+$//'
+}
+
+# Shared tag lookup for _build_number. Most recent reachable x.y.z tag;
+# v-prefixed tags are used only for lookup, never emitted (Debian Version:
+# must start with a digit).
+_anchor_tag() {
+    local tag=""
+    tag=$(git describe --first-parent --tags --abbrev=0 \
+        --match "$TAG_MATCH" 2>/dev/null) || true
+    if [[ -z "$tag" ]]; then
+        tag=$(git describe --first-parent --tags --abbrev=0 \
+            --match "$VTAG_MATCH" 2>/dev/null) || true
+    fi
+    echo "$tag"
+}
+
+# Resolve the git ref for CI branch detection. Prefer GITHUB_REF when set,
+# then parse /work/EVENT. jq handles normal JSON; grep fallback tolerates
+# spaced payloads ("ref": "...") that the original compact-json grep missed.
+_ci_ref() {
+    if [[ -n "${GITHUB_REF:-}" ]]; then
+        echo "$GITHUB_REF"
+        return
+    fi
+    if [[ ! -f /work/EVENT ]]; then
+        return
+    fi
+    if command -v jq >/dev/null 2>&1; then
+        jq -r '.ref // empty' /work/EVENT 2>/dev/null
+        return
+    fi
+    grep -oE '"ref"[[:space:]]*:[[:space:]]*"[^"]*"' /work/EVENT 2>/dev/null |
+        head -1 | sed -E 's/.*"([^"]*)".*/\1/'
+}
+
+# Determine branch when not in the /work/VERSION CI path. Tries, in order:
+# local branch name, GitHub/GitLab CI env vars (covers detached HEAD checkouts),
+# then the first remote branch containing HEAD (legacy fallback).
+_resolve_branch() {
+    local branch=""
+
+    branch="$(git branch --show-current 2>/dev/null || true)"
+    if [[ -n "$branch" ]]; then
+        echo "$branch"
+        return
+    fi
+
+    if [[ -n "${GITHUB_HEAD_REF:-}" ]]; then
+        echo "$GITHUB_HEAD_REF"
+        return
+    fi
+    if [[ -n "${GITHUB_REF:-}" && "$GITHUB_REF" == refs/heads/* ]]; then
+        echo "${GITHUB_REF#refs/heads/}"
+        return
+    fi
+    if [[ -n "${CI_COMMIT_REF_NAME:-}" ]]; then
+        echo "$CI_COMMIT_REF_NAME"
+        return
+    fi
+
+    # grep -Ev '/HEAD ->' avoids matching symbolic HEAD refs; strip remote prefix.
+    branch="$(git branch -r --contains HEAD 2>/dev/null |
+        grep -Ev '/HEAD ->' | head -1 |
+        sed -e 's|^[^/]*/||' -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//' || true)"
+    echo "$branch"
+}
 
 # ---------------------------------------------------------------------------
 # Build-number calculation
@@ -49,19 +149,13 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 _build_number() {
     local bn_branch="$1"
 
-    if [[ "$bn_branch" != "master" ]]; then
+    if ! _is_release_branch "$bn_branch"; then
         echo "1"
         return
     fi
 
     local base_tag
-    base_tag=$(git describe --first-parent --tags --abbrev=0 \
-        --match '[0-9]*.[0-9]*.[0-9]*' 2>/dev/null) || true
-    if [[ -z "$base_tag" ]]; then
-        base_tag=$(git describe --first-parent --tags --abbrev=0 \
-            --match 'v[0-9]*.[0-9]*.[0-9]*' 2>/dev/null) || true
-    fi
-
+    base_tag="$(_anchor_tag)"
     if [[ -n "$base_tag" ]]; then
         git rev-list --first-parent --count "${base_tag}..HEAD"
     else
@@ -69,22 +163,57 @@ _build_number() {
     fi
 }
 
+# CI-only: when /work/VERSION carries a describe string (x.y.z-n-g<sha>), use
+# the embedded n rather than recomputing from git. Prevents mismatches when the
+# CI checkout is shallow or tags are not fully fetched.
+_build_number_from_version() {
+    local ver="$1" branch="$2"
+
+    if [[ "$ver" =~ -([0-9]+)-g[0-9a-f]+$ ]]; then
+        echo "${BASH_REMATCH[1]}"
+        return
+    fi
+    _build_number "$branch"
+}
+
+# Shared release-line output for version_only and full modes on master.
+_emit_release_version() {
+    local rev="$1" branch="$2" output_mode="$3"
+
+    case "$output_mode" in
+    version_only) echo "$rev" ;;
+    full)
+        local bn
+        bn="$(_build_number "$branch")"
+        # Omit -n when n is 0 (HEAD exactly on the release tag).
+        [[ "$bn" == "0" ]] && echo "$rev" || echo "${rev}-${bn}"
+        ;;
+    esac
+}
+
+# Git-describe path requires a repo; the /work/VERSION CI path does not.
+_require_git_repo() {
+    git rev-parse --git-dir >/dev/null 2>&1 || {
+        echo "error: not a git repository" >&2
+        exit 1
+    }
+}
+
 # ---------------------------------------------------------------------------
-# Determine branch
+# Determine branch / release-line flag
 # ---------------------------------------------------------------------------
 is_release_line=false
 
 if [[ -f /work/VERSION ]]; then
     # CI environment: read pre-computed version and derive branch from event payload.
     rev="$(cat /work/VERSION)"
-    if [[ -f /work/EVENT ]]; then
-        REF="$(grep -o '"ref":"[^"]*"' /work/EVENT 2>/dev/null | head -1 | cut -d'"' -f4)"
-        if [[ "$REF" == "refs/heads/master" ]]; then
-            is_release_line=true
-        fi
+    REF="$(_ci_ref)"
+    if [[ "$REF" == "refs/heads/master" ]]; then
+        is_release_line=true
     fi
+
     if [[ "$is_release_line" == true ]]; then
-        rev="$(echo "$rev" | sed 's/-[0-9]*-g[0-9a-f]*$//')"
+        rev="$(echo "$rev" | _strip_describe_suffix)"
         branch="master" # placeholder; only used for _build_number below
     else
         branch=""
@@ -92,10 +221,11 @@ if [[ -f /work/VERSION ]]; then
 
     case "$mode" in
     version_only) echo "$rev" ;;
-    build_only) _build_number "${branch:-}" ;;
+    build_only) _build_number_from_version "$rev" "${branch:-}" ;;
     full)
         if [[ "$is_release_line" == true ]]; then
-            bn="$(_build_number "${branch:-}")"
+            # Re-read the raw VERSION for build-number extraction (before suffix strip).
+            bn="$(_build_number_from_version "$(cat /work/VERSION)" "${branch:-}")"
             [[ "$bn" == "0" ]] && echo "$rev" || echo "${rev}-${bn}"
         else
             echo "$rev"
@@ -108,14 +238,11 @@ fi
 # ---------------------------------------------------------------------------
 # Git-describe path (local / standard CI without /work/VERSION)
 # ---------------------------------------------------------------------------
-branch="$(git branch --show-current)"
+_require_git_repo
 
-if [[ -z "$branch" ]]; then
-    branch="$(git branch -r --contains HEAD | grep -v HEAD | head -1 |
-        sed -e 's/origin\///' -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
-fi
+branch="$(_resolve_branch)"
 
-if [[ "$branch" == "master" ]]; then
+if _is_release_branch "$branch"; then
     is_release_line=true
 fi
 
@@ -127,21 +254,14 @@ fi
 # Anchor on the bare x.y.z tag only (never a leading-v ship tag).
 if [[ "$is_release_line" == true ]]; then
     rev="$(git describe --first-parent --tags --always --abbrev=9 --long \
-        --match '[0-9]*.[0-9]*.[0-9]*' 2>/dev/null |
-        sed 's/-[0-9]*-g[0-9a-f]*$//')"
+        --match "$TAG_MATCH" 2>/dev/null | _strip_describe_suffix || true)"
     if [[ -z "$rev" ]]; then
         rev="$(git rev-parse --short=9 HEAD)"
     fi
-    case "$mode" in
-    version_only) echo "$rev" ;;
-    full)
-        bn="$(_build_number "$branch")"
-        [[ "$bn" == "0" ]] && echo "$rev" || echo "${rev}-${bn}"
-        ;;
-    esac
+    _emit_release_version "$rev" "$branch" "$mode"
 else
     rev="$(git describe --first-parent --tags --always --abbrev=9 --long \
-        --match '[0-9]*.[0-9]*.[0-9]*' 2>/dev/null)"
+        --match "$TAG_MATCH" 2>/dev/null || true)"
     if [[ -z "$rev" ]]; then
         rev="$(git rev-parse --short=9 HEAD)"
     fi

--- a/build/version
+++ b/build/version
@@ -58,9 +58,11 @@ while [[ $# -gt 0 ]]; do
     shift
 done
 
-# Glob patterns for semver x.y.z tags. Require at least one digit per segment
-# ([0-9][0-9]* instead of [0-9]*) to avoid matching empty or degenerate tags.
-TAG_MATCH='[0-9][0-9]*.[0-9][0-9]*.[0-9][0-9]*'
+# Glob patterns for semver x.y.z tags. git --match uses glob, NOT regex: a segment
+# must be [0-9]* (a leading digit, so 'staging.v1' is excluded). It must NOT be
+# [0-9][0-9]*, which in a glob means two-or-more digits and so never matches asmt's
+# single-digit segments (2.2.1, 1.0.0, ...), leaving every build SHA-versioned.
+TAG_MATCH='[0-9]*.[0-9]*.[0-9]*'
 VTAG_MATCH="v${TAG_MATCH}"
 
 # ---------------------------------------------------------------------------

--- a/pkg/Makefile.deb
+++ b/pkg/Makefile.deb
@@ -5,7 +5,10 @@ export DEB_BUILD_ROOT = $(DEB_SOURCE_ROOT)/BUILD
 export CL_BASE = $(DEB_BUILD_ROOT)/opt/aerospike
 export ETC_BASE = $(DEB_BUILD_ROOT)/etc/aerospike
 
-REV = $(shell build/version)
+REV = $(shell build/version -v)
+# Build number = commits since the tag, +1 so the tagged release is 1. It goes in the
+# debian revision (with the OS), so successive master builds are orderable by apt/dpkg.
+BUILD_NUMBER = $(shell expr $$(build/version -r) + 1)
 OS = $(shell build/os_version)
 ARCH=$(shell uname -m)
 MANIFEST_DIR = manifest/TEMP
@@ -44,10 +47,10 @@ dist:
 	ln -sf /opt/aerospike/bin/asmt $(DEB_BUILD_ROOT)/usr/bin/asmt
 
 
-	sed 's/@VERSION@/'$(REV)'/g' <pkg/deb/control >$(DEB_BUILD_ROOT)/DEBIAN/control
+	sed 's/@VERSION@/'$(REV)-$(BUILD_NUMBER)$(OS)'/g' <pkg/deb/control >$(DEB_BUILD_ROOT)/DEBIAN/control
 	sed -i 's/@ARCH@/'$(ARCH)'/g' $(DEB_BUILD_ROOT)/DEBIAN/control
 
-	fakeroot dpkg-deb -Z xz --build $(DEB_BUILD_ROOT) target/packages/asmt_$(REV)-1$(OS)_$(ARCH).deb
+	fakeroot dpkg-deb -Z xz --build $(DEB_BUILD_ROOT) target/packages/asmt_$(REV)-$(BUILD_NUMBER)$(OS)_$(ARCH).deb
 	rm -rf dist
 
 distclean:

--- a/pkg/Makefile.rpm
+++ b/pkg/Makefile.rpm
@@ -6,7 +6,11 @@ export CL_BASE = $(RPM_BUILD_ROOT)/opt/aerospike
 export ETC_BASE = $(RPM_BUILD_ROOT)/etc/aerospike
 
 MANIFEST_DIR = manifest/TEMP
-REV = $(shell build/version | sed 's/-/_/g')
+# Version (bare x.y.z on master; git-describe with SHA on dev branches). RPM Version
+# forbids '-', so map it to '_'. The build number (commits since the tag, +1 so the
+# tagged release is 1) is the Release.
+REV = $(shell build/version -v | sed 's/-/_/g')
+BUILD_NUMBER = $(shell expr $$(build/version -r) + 1)
 OS = $(shell build/os_version)
 ARCH = $(shell uname -m)
 
@@ -18,7 +22,7 @@ default: dist
 	mkdir -p $(RPM_BUILD_ROOT)/usr/bin
 
 	sed 's/@VERSION@/'$(REV)'/g' <pkg/rpm/asmt.spec >pkg/asmt_v.spec
-	sed -i 's/@RELEASE@/'$(OS)'/g' pkg/asmt_v.spec
+	sed -i 's/@RELEASE@/'$(BUILD_NUMBER)'/g' pkg/asmt_v.spec
 	sed -i 's/@ARCH@/'$(ARCH)'/g' pkg/asmt_v.spec
 
 	rpmbuild --noclean -bb -vv --define "dist .$(OS)" --buildroot $(RPM_BUILD_ROOT) pkg/asmt_v.spec

--- a/pkg/rpm/asmt.spec
+++ b/pkg/rpm/asmt.spec
@@ -1,6 +1,6 @@
 Name: asmt
 Version: @VERSION@
-Release: 1%{?dist}
+Release: @RELEASE@%{?dist}
 Summary: The Aerospike Shared Memory Tool
 License: Apache 2.0 license
 Group: Application


### PR DESCRIPTION
## What

Replaces asmt's bare `git describe` version script with a unified version/build-number resolver (ported from `aerospike-server`, adapted for asmt), and wires the **build number** into the RPM `Release` / DEB revision so packages are versioned and upgrade-orderable.

## Why

The old `build/version` always emitted the bare `x.y.z` tag, so a build several commits past a release was indistinguishable from the release itself, and successive builds of the same version couldn't be ordered by `rpm`/`apt`. The new script encodes the version, the build number, and (on dev branches) the commit SHA.

## `build/version` — modes & resolution

| Invocation | `master` | dev branches |
|---|---|---|
| `build/version` *(default)* | `x.y.z-n` (bare `x.y.z` when `n == 0`) | `x.y.z-n-g<sha>` |
| `build/version -v` | `x.y.z` (bare) | `x.y.z-n-g<sha>` |
| `build/version -r` | build number `n` | `1` |

`n` = first-parent commits since the anchoring `x.y.z` tag.

- **Tag anchor**: `--match '[0-9]*.[0-9]*.[0-9]*'` (bare 3-part semver; `staging.v1` excluded). Never emits a leading `v` (the Debian `Version:` field requires a leading digit).
- **Release-line (master) detection**, in order: CI ref signals (`GITHUB_HEAD_REF` / `GITHUB_REF` / `CI_COMMIT_REF_NAME`) so it's correct under `actions/checkout`'s **detached HEAD**; then the checked-out branch name; then the first remote branch containing HEAD. `master` is the only release line (asmt has no hotfix branches).
- **No pre-baked version files** — version is always derived from git tags via `git describe`. On describe failure (old git / shallow clone) it warns to stderr before falling back to a short SHA, so a mis-provisioned runner is visible rather than silently shipping a SHA-versioned package. (`--first-parent` needs git ≥ 2.20 — fine on debian:10+/ubuntu-20.04+; the retired ubuntu-18.04/git-2.17 leg is below it.)

## Packaging — build number in `Release` / revision

`pkg/Makefile.rpm` and `pkg/Makefile.deb` split the outputs: `REV` from `build/version -v` (bare `x.y.z`; rpm maps `-`→`_`), and `BUILD_NUMBER = build/version -r + 1` (so the tagged release is `1`) into the RPM `Release` (`asmt.spec` `Release: @RELEASE@%{?dist}`) and the DEB revision (in **both** the control `Version:` and the filename, so `apt`/`dpkg` order successive master builds).

| | master (on tag `2.2.1`) | master (3 commits past) | dev branch |
|---|---|---|---|
| RPM | `asmt-2.2.1-1.el8.aarch64.rpm` | `asmt-2.2.1-4.el8.aarch64.rpm` | `asmt-2.2.1_3_g<sha>-2.el10.x86_64.rpm` |
| DEB | `asmt_2.2.1-1debian13_arm64.deb` | `asmt_2.2.1-4debian13_arm64.deb` | `asmt_2.2.1-3-g<sha>-2debian13_arm64.deb` |

## Review feedback addressed

- **Critical — tag glob fixed.** `TAG_MATCH` had been `[0-9][0-9]*.[0-9][0-9]*.[0-9][0-9]*`; git `--match` is glob (not regex), so `[0-9][0-9]*` means *two-or-more* digits and matched **none** of asmt's single-digit-segment tags (`2.2.1`, `1.0.0`, …) → `git describe` failed → every package was SHA-versioned. Now `[0-9]*.[0-9]*.[0-9]*`.
- Detached-HEAD release detection via CI ref signals (was the fragile "first remote branch containing HEAD").
- Removed the aerospike-server `/work/VERSION` block (asmt has no producer for it).
- `n == 0` suppression so on-tag release builds stay bare `x.y.z`.
- Dropped `hotfix/*` handling; header no longer references `gen_version` / `README-VERSIONING.md` (asmt hardcodes its version in `src/asmt.c`).

## Testing

- `bash -n build/version` clean.
- All three modes exercised on `master` (attached branch, `git clone` job), on `master` via `GITHUB_REF` under a **detached** worktree (the ubuntu `actions/checkout` job), and on a dev branch — plus scratch-repo runs for on-tag (`n=0`), post-tag (`n>0`), and detached-HEAD cases.
- Package naming validated through the real `make -f pkg/Makefile.{rpm,deb} print-REV print-BUILD_NUMBER` path; `dpkg --compare-versions` confirms successive builds are orderable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
