### PR TITLE
make build/version -r 1-based so dev packages are revision 1

### DIFF
--- a/build/version
+++ b/build/version
@@ -6,11 +6,12 @@
 #   build/version              -> master: x.y.z-n; dev branches: git describe with SHA
 #   build/version -v           -> master: x.y.z (bare);
 #                                 dev branches: git describe with SHA (same as default)
-#   build/version -r           -> master: build number n; dev branches: 1
+#   build/version -r           -> master: build number (tagged release = 1); dev: 1
 #
 # Consumed by pkg/Makefile.rpm and pkg/Makefile.deb: REV = `build/version -v`
 # (bare x.y.z; the rpm Makefile maps '-' to '_') for the package Version, and the
-# build number (`build/version -r` + 1) feeds the RPM Release / DEB revision.
+# build number `build/version -r` (1-based: tagged release and dev builds are 1)
+# feeds the RPM Release / DEB revision.
 #
 # Resolution rules:
 # - Always anchors on the bare x.y.z release tag via
@@ -24,7 +25,8 @@
 # - Dev branches: keep the full describe output (-<n>-g<sha>); build number is 1.
 #
 # build_number counts first-parent commits since the anchoring x.y.z tag (0 when
-# HEAD is exactly on the tag). Non-master branches always return 1.
+# HEAD is exactly on the tag). Non-master branches always return 1. The -r output
+# adds 1 on release lines so the tagged release is build number 1.
 # --first-parent requires git >= 2.20 (debian:10+; ubuntu-18.04/git 2.17 is below).
 #
 # Version is always derived from git tags via git-describe (through make print-REV).
@@ -208,7 +210,13 @@ if _is_release_branch "$branch"; then
 fi
 
 if [[ "$mode" == "build_only" ]]; then # -r
-    _build_number "$branch"
+    # 1-based build number so the tagged release is 1 (dev branches are already 1);
+    # feeds the RPM Release / DEB revision directly (no +1 in the Makefiles).
+    if [[ "$is_release_line" == true ]]; then
+        echo "$(( $(_build_number "$branch") + 1 ))"
+    else
+        _build_number "$branch"
+    fi
     exit 0
 fi
 

--- a/pkg/Makefile.deb
+++ b/pkg/Makefile.deb
@@ -6,9 +6,9 @@ export CL_BASE = $(DEB_BUILD_ROOT)/opt/aerospike
 export ETC_BASE = $(DEB_BUILD_ROOT)/etc/aerospike
 
 REV = $(shell build/version -v)
-# Build number = commits since the tag, +1 so the tagged release is 1. It goes in the
-# debian revision (with the OS), so successive master builds are orderable by apt/dpkg.
-BUILD_NUMBER = $(shell expr $$(build/version -r) + 1)
+# Build number from build/version -r (1-based: tagged release and dev builds are 1). It
+# goes in the debian revision (with the OS), so successive master builds are orderable.
+BUILD_NUMBER = $(shell build/version -r)
 OS = $(shell build/os_version)
 ARCH=$(shell uname -m)
 MANIFEST_DIR = manifest/TEMP

--- a/pkg/Makefile.rpm
+++ b/pkg/Makefile.rpm
@@ -7,10 +7,10 @@ export ETC_BASE = $(RPM_BUILD_ROOT)/etc/aerospike
 
 MANIFEST_DIR = manifest/TEMP
 # Version (bare x.y.z on master; git-describe with SHA on dev branches). RPM Version
-# forbids '-', so map it to '_'. The build number (commits since the tag, +1 so the
-# tagged release is 1) is the Release.
+# forbids '-', so map it to '_'. The build number (build/version -r, 1-based so the
+# tagged release and dev builds are 1) is the Release.
 REV = $(shell build/version -v | sed 's/-/_/g')
-BUILD_NUMBER = $(shell expr $$(build/version -r) + 1)
+BUILD_NUMBER = $(shell build/version -r)
 OS = $(shell build/os_version)
 ARCH = $(shell uname -m)
 


### PR DESCRIPTION
## Summary

Follow-up to #42. `build/version -r` was **0-based on release lines** (0 on the tag) with the Makefiles adding `+1`, but it returned **1 on dev branches** — so dev packages came out as revision **2** (`x.y.z-<n>-g<sha>-2`) while master releases were `1`. This makes `-r` uniformly **1-based** so dev packages are `-1`, consistent with the tagged release.

## Change

- **`build/version`**: move the `+1` into the `-r` (build_only) path — applied on release lines only; dev branches already return `1`. `-r` is now the 1-based build number directly.
- **`pkg/Makefile.{deb,rpm}`**: `BUILD_NUMBER = build/version -r` (dropped the `expr … + 1`).

`_build_number` and the default/full-mode output (bare `x.y.z` on the release tag, 0-based `-n` commits-ahead count) are **unchanged**.

## Package names

| | before | after |
|---|---|---|
| master on tag | `asmt_x.y.z-1<os>…` | `asmt_x.y.z-1<os>…` (unchanged) |
| master N past tag | `asmt_x.y.z-<N+1><os>…` | same (unchanged) |
| **dev branch** | `asmt_x.y.z-<n>-g<sha>-`**`2`**`<os>…` | `asmt_x.y.z-<n>-g<sha>-`**`1`**`<os>…` |

Brings asmt in line with the 1-based convention in [aerospike/act#81](https://github.com/aerospike/act/pull/81) and [aerospike-tools-validation#41](https://github.com/aerospike/aerospike-tools-validation/pull/41).

## Test plan

- [x] `bash -n build/version`; scratch-repo verification of master on/off-tag, dev
- [x] `-r` = 1 on dev and on the tagged release, 3 two commits past
- [x] default/full mode output confirmed unchanged (bare release, dev full describe)
